### PR TITLE
Tailscale service must be started post-update

### DIFF
--- a/packages/tailscale-pikvm/tailscale-pikvm.install
+++ b/packages/tailscale-pikvm/tailscale-pikvm.install
@@ -10,6 +10,6 @@ post_upgrade() {
 	mkdir -p /var/lib/tailscale || true
 	chmod 700 /var/lib/tailscale || true
 	if [ "$service_enabled" == "enabled" ]; then
-		systemctl enable tailscaled || true
+		systemctl enable --now tailscaled || true
 	fi
 }


### PR DESCRIPTION
Hey @mdevaev, tailscaled must be started while the filesystem is writeable. I confirmed in the current release this does not fix the issue because the service cannot be started even though it is enabled because of the read-only file system. Using --now or starting it in the post-update script will allow for the service to create/update the files it needs before the system goes back to ro mode.

I tested with 0.6 update and before reboot, if I ran:

`systemctl enable --now tailscaled`
or
`systemctl start tailscaled`

I did not lose access and the server version was updated. I then rebooted and it still worked because the initial start created/update the configuration required.

The only thing I am not sure on is if it will get angry trying to run the service in a post_update method.