### PR TITLE
Allow declarative configuration of tailscale

### DIFF
--- a/packages/pikvm-os-updater/pikvm-update.sh
+++ b/packages/pikvm-os-updater/pikvm-update.sh
@@ -124,8 +124,9 @@ fi
 pacman $_yes -Su
 
 if systemctl is-enabled -q tailscaled; then
+	source /etc/default/tailscale
 	systemctl restart tailscaled
-	tailscale up
+	tailscale up ${TAILSCALE_FLAGS}
 fi
 
 if ! kvmd -m >/dev/null 2>&1; then

--- a/packages/tailscale-pikvm/PKGBUILD
+++ b/packages/tailscale-pikvm/PKGBUILD
@@ -6,12 +6,14 @@ url="https://tailscale.com"
 license=(GPL)
 arch=(any)
 depends=("tailscale>=1.30.1")
-source=(pikvm-logs-dir.conf after-kvmd-nginx.conf)
+source=(pikvm-logs-dir.conf after-kvmd-nginx.conf tailscale)
 md5sums=(SKIP SKIP)
 install=tailscale-pikvm.install
 
 package() {
 	mkdir -p "$pkgdir/etc/systemd/system/tailscaled.service.d"
+	mkdir -p "$pkgdir/etc/default"
 	install -m644 pikvm-logs-dir.conf "$pkgdir/etc/systemd/system/tailscaled.service.d"
 	install -m644 after-kvmd-nginx.conf "$pkgdir/etc/systemd/system/tailscaled.service.d"
+	install -m644 tailscale "$pkgdir/etc/default"
 }

--- a/packages/tailscale-pikvm/tailscale
+++ b/packages/tailscale-pikvm/tailscale
@@ -1,0 +1,1 @@
+TAILSCALE_FLAGS=""


### PR DESCRIPTION
Doing it this way should prevent tailscale from losing its confiuration on pikvm-update